### PR TITLE
管理エリアのコメント操作の改善(リンクまわり)

### DIFF
--- a/nucleus/language/japanese-utf8.php
+++ b/nucleus/language/japanese-utf8.php
@@ -17,6 +17,11 @@
 // Note for Japanese users
 // このファイルは Nucleus の UTF-8 版日本語ランゲージファイルです。
 
+define('_LIST_BACK_TO',				'%sに戻る');
+define('_LIST_COMMENT_LIST_FOR_BLOG',		'ブログのコメント一覧');
+define('_LIST_COMMENT_LIST_FOR_ITEM',		'アイテムのコメント一覧');
+define('_LIST_COMMENT_VIEW_ITEM',			'アイテムを表示');
+
 define('_LISTS_ITEM_COUNT',	'アイテム数');
 define('_LISTS_ORDER',	'並び順');
 

--- a/nucleus/libs/ADMIN.php
+++ b/nucleus/libs/ADMIN.php
@@ -828,7 +828,7 @@ class ADMIN {
 					{
 						$s .= sprintf('<tr><td>%s</td><td>%s</td><td>%s</td></tr>'
 									, hsc($o->corder), hsc($o->cname), hsc($o->cdesc)
-						);  			  
+						);
 						continue;
 					}
 			  }
@@ -1058,9 +1058,27 @@ class ADMIN {
 				$amount = 10;
 		}
 
+		printf('<p>(<a href="index.php?action=itemlist&amp;blogid=%s">%s</a> | '.
+               '<a href="index.php?action=blogcommentlist&amp;blogid=%s">%s</a>)</p>',
+                $blogid , hsc(_BACKTOOVERVIEW) ,
+                $blogid , hsc(sprintf(_LIST_BACK_TO , _LIST_COMMENT_LIST_FOR_BLOG))
+                );
+
+        echo '<h2>',_LIST_COMMENT_LIST_FOR_ITEM,'</h2>';
+
+		$item =& $manager->getItem($itemid, true, true);
+        echo "<div>";
+        echo _LIST_ITEM_CONTENT . ' : ';
+        printf("<a href='%s#c' title='%s'><img src='images/globe.gif' width='13' height='13' style='vertical-align:middle;' /></a> %s</div>",
+                    createItemLink($itemid) ,
+                    htmlentities(_LIST_COMMENT_VIEW_ITEM, ENT_COMPAT, _CHARSET) ,
+                    hsc(shorten($item["title"], 100, '...'))
+                );
+		printf("<div style=' margin-left: 20px; padding: 5px'>%s</div>",
+                  hsc(shorten(strip_tags($item["body"]), 100, '...')) . '<br />');
+
 		$search = postVar('search');
 
-		echo '<p>(<a href="index.php?action=itemlist&amp;blogid=',$blogid,'">',_BACKTOOVERVIEW,'</a>)</p>';
 		echo '<h2>',_COMMENTS,'</h2>';
 
 		$query = 'SELECT cbody, cuser, cmail, cemail, mname, ctime, chost, cnumber, cip, citem FROM ' . sql_table('comment') . ' LEFT OUTER JOIN ' . sql_table('member') . ' ON mnumber = cmember WHERE citem = ' . $itemid;

--- a/nucleus/libs/showlist.php
+++ b/nucleus/libs/showlist.php
@@ -387,9 +387,14 @@ function listplug_nextBatchId() {
 }
 
 function listplug_table_commentlist($template, $type) {
+    static $amountComments = array();
+	$colspan = 3;
+	if ( isset($_GET['action']) && ($_GET['action'] == 'blogcommentlist') )
+	   $colspan++;
+
 	switch($type) {
 		case 'HEAD':
-			echo "<th>"._LISTS_INFO."</th><th>"._LIST_COMMENT."</th><th colspan='3'>"._LISTS_ACTIONS."</th>";
+			echo "<th>"._LISTS_INFO."</th><th>"._LIST_COMMENT."</th><th colspan='${colspan}'>"._LISTS_ACTIONS."</th>";
 			break;
 		case 'BODY':
 			$current = $template['current'];
@@ -427,7 +432,26 @@ function listplug_table_commentlist($template, $type) {
 			echo "<td style=\"white-space:nowrap\"><a href='index.php?action=commentdelete&amp;commentid=$current->cnumber'>"._LISTS_DELETE."</a></td>";
 			if ($template['canAddBan'])
 				echo "<td style=\"white-space:nowrap\"><a href='index.php?action=banlistnewfromitem&amp;itemid=$current->citem&amp;ip=", hsc($current->cip), "' title='", hsc($current->chost), "'>"._LIST_COMMENT_BANIP."</a></td>";
-			break;
+
+			$action = isset($_GET['action']) ? strval( $_GET['action'] ) : '';
+			// add link
+			if ($action == 'blogcommentlist')
+			 {
+                if (!isset($amountComments[$current->citem]))
+                {
+                    $COMMENTS = new COMMENTS($current->citem);
+                    $amountComments[$current->citem] = $COMMENTS->amountComments();
+                }
+				echo '<td style=" word-break: break-all">';
+				$s = sprintf('(%d) %s' , $amountComments[$current->citem], _LIST_COMMENT_LIST_FOR_ITEM);
+				$s = sprintf(_LIST_BACK_TO, $s);
+				printf('<a href="index.php?action=itemcommentlist&itemid=%d">%s</a></td>'
+					   , $current->citem , $s );
+				echo '</td>';
+			 }
+			// end link
+
+            break;
 	}
 }
 


### PR DESCRIPTION
(1) action=blogcommentlist にアイテムのコメント一覧へのリンクを追加しました
(2) action=itemcommentlist に 以下を追加しました
　・アイテムのコメント一覧 と表示する
  ・ブログのコメント一覧 へのリンクを追加
  ・アイテムのタイトルと内容(100文字で切り捨て)を表示
  ・アイテムを見るためのリンクを追加