### PR TITLE
関数 MEMBER：：writeCookieKey()を追加

### DIFF
--- a/nucleus/libs/MEMBER.php
+++ b/nucleus/libs/MEMBER.php
@@ -471,6 +471,15 @@ class MEMBER {
 		sql_query($query);
 	}
 
+	function writeCookieKey()
+	{
+		$query =  'UPDATE '.sql_table('member')
+			   . " SET "
+			   . "     mcookiekey='". sql_real_escape_string($this->getCookieKey()) . "'"
+			   . " WHERE mnumber=" . $this->getID();
+		sql_query($query);
+	}
+
 	function checkCookieKey($key) {
 		return (($key != '') && ($key == $this->getCookieKey()));
 	}
@@ -543,7 +552,7 @@ class MEMBER {
 	function newCookieKey() {
 		mt_srand( (double) microtime() * 1000000);
 		$this->cookiekey = md5(uniqid(mt_rand()));
-		$this->write();
+		$this->writeCookieKey();
 		return $this->cookiekey;
 	}
 

--- a/nucleus/libs/globalfunctions.php
+++ b/nucleus/libs/globalfunctions.php
@@ -269,7 +269,7 @@ if ($action == 'login') {
 		if ($CONF['secureCookieKey']!=='none') {
 			// secure cookie key
 			$member->setCookieKey(md5($member->getCookieKey().$CONF['secureCookieKeyIP']));
-			$member->write();
+			$member->writeCookieKey();
 		}
 
 		// allows direct access to parts of the admin area after logging in


### PR DESCRIPTION
・globalfunctions.php の ログイン処理時の以下の呼び出しの潜在的問題点の修正のため
$member->newCookieKey();
$member->write();
(1)ログイン時に不要な値を更新している
(2)dbのメンバーテーブルに将来的になんらかの修正を加えた場合に
   cookieを保存できず ログイン・アップグレードできなくなる不具合を起ことがあるため。