### PR TITLE
PHP 7.0.0 RC 5 への対応 と インストールできない問題の修正

### DIFF
--- a/install/index.php
+++ b/install/index.php
@@ -56,7 +56,9 @@ $aConfSkinsToImport = array(
 error_reporting(E_ERROR | E_WARNING | E_PARSE);
 
 // make sure there's no unnecessary escaping:
-set_magic_quotes_runtime(0);
+if (version_compare(PHP_VERSION, '5.3.0', '<')) {
+    set_magic_quotes_runtime(0);
+}
 
 // if there are some plugins or skins to import, do not include vars
 // in globalfunctions.php again... so set a flag
@@ -85,7 +87,11 @@ global $MYSQL_HANDLER;
 //set the handler if different from mysql (or mysqli)
 //$MYSQL_HANDLER = array('pdo','mysql');
 if (!isset($MYSQL_HANDLER)) {
-	$MYSQL_HANDLER = array('mysql','');
+	if ( extension_loaded('mysql') ) {
+		$MYSQL_HANDLER = array('mysql','');
+	} else {
+		$MYSQL_HANDLER = array('pdo','mysql');
+	}
 }
 include_once('../nucleus/libs/sql/'.$MYSQL_HANDLER[0].'.php');
 // end new for 3.5 sql_* wrapper
@@ -611,6 +617,10 @@ function doInstall() {
 	if ($MYSQL_CONN == false) {
 		_doError(_ERROR15 . ': ' . sql_error() );
 	}
+	
+	global $MYSQL_HANDLER , $SQL_DBH;
+	if ($MYSQL_HANDLER[0] == 'pdo')
+		$SQL_DBH = $MYSQL_CONN;
 
 	// 3. try to create database (if needed)
 	$mySqlVer = implode('.', array_map('intval', explode('.', sql_get_server_info())));

--- a/nucleus/libs/globalfunctions.php
+++ b/nucleus/libs/globalfunctions.php
@@ -169,6 +169,12 @@ $manager =& MANAGER::instance();
 //set_magic_quotes_runtime(0);
 if (version_compare(PHP_VERSION, '5.3.0', '<')) {
 	ini_set('magic_quotes_runtime', '0');
+} else {
+	if (!function_exists('set_magic_quotes_runtime'))
+	{
+		// This function was DEPRECATED in PHP 5.3.0, and REMOVED as of PHP 7.0.0.
+		function set_magic_quotes_runtime() { return FALSE; }
+	}
 }
 
 // Avoid notices

--- a/nucleus/libs/sql/pdo.php
+++ b/nucleus/libs/sql/pdo.php
@@ -238,7 +238,9 @@ if (!function_exists('sql_fetch_assoc'))
 //echo $query.'<hr />';
 		if (is_null($dbh)) $res = $SQL_DBH->query($query);
 		else $res = $dbh->query($query);
-		if ($res->errorCode() != '00000') {
+		if ($res === false) {
+			print("SQL error with query $query: " . '<p />');
+		} else if ($res->errorCode() != '00000') {
 			$errors = $res->errorInfo();
 			print("SQL error with query $query: " . $errors[0].'-'.$errors[1].' '.$errors[2] . '<p />');
 		}


### PR DESCRIPTION
PHP 7.0.0 RC 5 でインストールできない問題を修正しました。
試した項目：インストール、表示、管理画面にログイン。
アップグレードは試していないのでわかりません。