### PR TITLE
PHP5.6,PHP7のDeprecatedの修正

### DIFF
--- a/nucleus/libs/ACTION.php
+++ b/nucleus/libs/ACTION.php
@@ -19,7 +19,7 @@ class ACTION
 	/**
 	 *  Constructor for an new ACTION object
 	 */
-	function ACTION()
+	function __construct()
 	{
 		// do nothing
 	}

--- a/nucleus/libs/ACTIONLOG.php
+++ b/nucleus/libs/ACTIONLOG.php
@@ -23,7 +23,7 @@ class ACTIONLOG {
 	/**
 	  * (Static) Method to add a message to the action log
 	  */
-	function add($level, $message) {
+	public static function add($level, $message) {
 		global $member, $CONF;
 
 		if ($CONF['LogLevel'] < $level)
@@ -44,7 +44,7 @@ class ACTIONLOG {
 	/**
 	  * (Static) Method to clear the whole action log
 	  */
-	function clear() {
+	public static function clear() {
 		global $manager;
 
 		$query = 'DELETE FROM ' . sql_table('actionlog');
@@ -58,7 +58,7 @@ class ACTIONLOG {
 	/**
 	  * (Static) Method to trim the action log (from over 500 back to 250 entries)
 	  */
-	function trimLog() {
+	public static function trimLog() {
 		static $checked = 0;
 
 		// only check once per run

--- a/nucleus/libs/ACTIONS.php
+++ b/nucleus/libs/ACTIONS.php
@@ -37,9 +37,9 @@ class ACTIONS extends BaseActions {
 	/**
 	 * Constructor for a new ACTIONS object
 	 */
-	function ACTIONS($type) {
+	function __construct($type) {
 		// call constructor of superclass first
-		$this->BaseActions();
+		parent::__construct();
 
 		$this->skintype = $type;
 

--- a/nucleus/libs/ADMIN.php
+++ b/nucleus/libs/ADMIN.php
@@ -904,7 +904,7 @@ class ADMIN {
 	 * member has access
 	 * @see function selectBlog
 	 */
-	function selectBlogCategory($name, $selected = 0, $tabindex = 0, $showNewCat = 0, $iForcedBlogInclude = -1) {
+	public static function selectBlogCategory($name, $selected = 0, $tabindex = 0, $showNewCat = 0, $iForcedBlogInclude = -1) {
 		ADMIN::selectBlog($name, 'category', $selected, $tabindex, $showNewCat, $iForcedBlogInclude);
 	}
 
@@ -918,7 +918,7 @@ class ADMIN {
 	 *	  member is on the blog team (-1 = none)
 	 * @todo document parameters
 	 */
-	function selectBlog($name, $mode='blog', $selected = 0, $tabindex = 0, $showNewCat = 0, $iForcedBlogInclude = -1) {
+	public static function selectBlog($name, $mode='blog', $selected = 0, $tabindex = 0, $showNewCat = 0, $iForcedBlogInclude = -1) {
 		global $member, $CONF;
 
 		// 0. get IDs of blogs to which member can post items (+ forced blog)
@@ -3471,7 +3471,7 @@ class ADMIN {
 	 * @static
 	 * @todo document this
 	 */
-	function deleteOneMember($memberid) {
+	public static function deleteOneMember($memberid) {
 		global $manager;
 
 		$memberid = intval($memberid);
@@ -6781,7 +6781,7 @@ selector();
 	 * @static
 	 * @todo document this
 	 */
-	function _insertPluginOptions($context, $contextid = 0) {
+	public static function _insertPluginOptions($context, $contextid = 0) {
 		// get all current values for this contextid
 		// (note: this might contain doubles for overlapping contextids)
 		$aIdToValue = array();
@@ -6849,7 +6849,7 @@ selector();
 	 * Helper functions to create option forms etc.
 	 * @todo document parameters
 	 */
-	function input_yesno($name, $checkedval,$tabindex = 0, $value1 = 1, $value2 = 0, $yesval = _YES, $noval = _NO, $isAdmin = 0) {
+	public static function input_yesno($name, $checkedval,$tabindex = 0, $value1 = 1, $value2 = 0, $yesval = _YES, $noval = _NO, $isAdmin = 0) {
 		$id = hsc($name);
 		$id = str_replace('[','-',$id);
 		$id = str_replace(']','-',$id);

--- a/nucleus/libs/ADMIN.php
+++ b/nucleus/libs/ADMIN.php
@@ -4261,6 +4261,9 @@ selector();
 		$name = sql_real_escape_string($name);
 		$desc = sql_real_escape_string($desc);
 
+		// 0. clear SqlCache
+		$manager->clearCachedInfo('sql_fetch_object');
+
 		// 1. Remove all template parts
 		$query = 'DELETE FROM '.sql_table('template').' WHERE tdesc=' . $templateid;
 		sql_query($query);

--- a/nucleus/libs/ADMIN.php
+++ b/nucleus/libs/ADMIN.php
@@ -549,7 +549,10 @@ class ADMIN {
 					if (sql_num_rows($r) < 2)
 						$error = _ERROR_ATLEASTONEADMIN;
 					else
+					{
 						sql_query('UPDATE ' . sql_table('member') .' SET madmin=0 WHERE mnumber='.$memberid);
+						$error = '';
+					}
 					break;
 				default:
 					$error = _BATCH_UNKNOWN . hsc($action);

--- a/nucleus/libs/ADMIN.php
+++ b/nucleus/libs/ADMIN.php
@@ -28,7 +28,7 @@ class ADMIN {
 	/**
 	 * Class constructor
 	 */
-	function ADMIN() {
+	function __construct() {
 
 	}
 

--- a/nucleus/libs/BAN.php
+++ b/nucleus/libs/BAN.php
@@ -95,7 +95,7 @@ class BANINFO {
 	var $iprange;
 	var $message;
 
-	function BANINFO($iprange, $message) {
+	function __construct($iprange, $message) {
 		$this->iprange = $iprange;
 		$this->message = $message;
 	}

--- a/nucleus/libs/BAN.php
+++ b/nucleus/libs/BAN.php
@@ -20,7 +20,7 @@ class BAN {
 	  * Returns 0 when not banned, or a BANINFO object containing the
 	  * message and other information of the ban
 	  */
-	function isBanned($blogid, $ip) {
+	public static function isBanned($blogid, $ip) {
 		$blogid = intval($blogid);
 		$query = 'SELECT * FROM '.sql_table('ban').' WHERE blogid='.$blogid;
 		$res = sql_query($query);
@@ -36,7 +36,7 @@ class BAN {
 	/**
 	  * Adds a new ban to the banlist. Returns 1 on success, 0 on error
 	  */
-	function addBan($blogid, $iprange, $reason) {
+	public static function addBan($blogid, $iprange, $reason) {
 		global $manager;
 
 		$blogid = intval($blogid);
@@ -66,7 +66,7 @@ class BAN {
 	  * Removes a ban from the banlist (correct iprange is needed as argument)
 	  * Returns 1 on success, 0 on error
 	  */
-	function removeBan($blogid, $iprange) {
+	public static function removeBan($blogid, $iprange) {
 		global $manager;
 		$blogid = intval($blogid);
 

--- a/nucleus/libs/BLOG.php
+++ b/nucleus/libs/BLOG.php
@@ -37,7 +37,7 @@ class BLOG {
 	 *
 	 * @param $id blogid
 	 */
-	function BLOG($id) {
+	function __construct($id) {
 		$this->blogid = intval($id);
 		$this->readSettings();
 

--- a/nucleus/libs/BLOG.php
+++ b/nucleus/libs/BLOG.php
@@ -794,7 +794,7 @@ class BLOG {
 	  * ordered by  number, name, shortname or description
 	  * in ascending or descending order
 	  */
-	function showBlogList($template, $bnametype, $orderby, $direction) {
+	public static function showBlogList($template, $bnametype, $orderby, $direction) {
 		global $CONF, $manager;
 
 		switch ($orderby) {
@@ -1204,13 +1204,13 @@ class BLOG {
 	}
 
 	// returns true if there is a blog with the given shortname (static)
-	function exists($name) {
+	public static function exists($name) {
 		$r = sql_query('select * FROM '.sql_table('blog').' WHERE bshortname="'.sql_real_escape_string($name).'"');
 		return (sql_num_rows($r) != 0);
 	}
 
 	// returns true if there is a blog with the given ID (static)
-	function existsID($id) {
+	public static function existsID($id) {
 		$r = sql_query('select * FROM '.sql_table('blog').' WHERE bnumber='.intval($id));
 		return (sql_num_rows($r) != 0);
 	}

--- a/nucleus/libs/BODYACTIONS.php
+++ b/nucleus/libs/BODYACTIONS.php
@@ -19,8 +19,8 @@ class BODYACTIONS extends BaseActions {
 
 	var $template;
 
-	function BODYACTIONS () {
-		$this->BaseActions();	
+	function __construct() {
+		parent::__construct();
 	}
 	
 	function setCurrentItem(&$item) {

--- a/nucleus/libs/BaseActions.php
+++ b/nucleus/libs/BaseActions.php
@@ -42,7 +42,7 @@ class BaseActions {
 	// reference to the parser object that is using this object as actions-handler
 	var $parser;
 
-	function BaseActions() {
+	function __construct() {
 		$this->level = 0;
 
 		// if nesting level

--- a/nucleus/libs/COMMENT.php
+++ b/nucleus/libs/COMMENT.php
@@ -160,7 +160,7 @@ class COMMENT {
 	 * @param array $match
 	 * @return string
 	 */
-	function prepareBody_cb($match)
+	public static function prepareBody_cb($match)
 	{
 		if ( !preg_match('/^[a-z]+/i', $match[2], $protocol) )
 		{

--- a/nucleus/libs/COMMENT.php
+++ b/nucleus/libs/COMMENT.php
@@ -19,7 +19,7 @@ class COMMENT {
 	  *
 	  * @static
 	  */
-	function getComment($commentid) {
+	public static function getComment($commentid) {
 		$query = 'SELECT `cnumber` AS commentid, `cbody` AS body, `cuser` AS user, `cmail` AS userid, `cemail` AS email, `cmember` AS memberid, `ctime`, `chost` AS host, `mname` AS member, `cip` AS ip, `cblog` AS blogid'
 					. ' FROM ' . sql_table('comment') . ' LEFT OUTER JOIN ' . sql_table('member') . ' ON `cmember` = `mnumber`'
 					. ' WHERE `cnumber` = ' . intval($commentid);
@@ -39,7 +39,7 @@ class COMMENT {
 	  *
 	  * @static
 	  */
-	function prepare($comment)
+	public static function prepare($comment)
 	{
 		$comment['user'] = strip_tags($comment['user']);
 		$comment['userid'] = strip_tags($comment['userid']);
@@ -66,7 +66,7 @@ class COMMENT {
 	 *
 	 * @ static
 	 */
-	function prepareBody($body) {
+	public static function prepareBody($body) {
 
 		// convert Windows and Mac style 'returns' to *nix newlines
 		$body = preg_replace("/\r\n/", "\n", $body);
@@ -106,7 +106,7 @@ class COMMENT {
 	 *
 	 * @ static
 	 */
-	function createLinkCode($pre, $url, $protocol = 'http') {
+	public static function createLinkCode($pre, $url, $protocol = 'http') {
 		$post = '';
 
 		// it's possible that $url ends contains entities we don't want,

--- a/nucleus/libs/COMMENTACTIONS.php
+++ b/nucleus/libs/COMMENTACTIONS.php
@@ -24,9 +24,9 @@ class COMMENTACTIONS extends BaseActions {
 	// comment currenlty being handled (mysql result assoc array; see COMMENTS::showComments())
 	var $currentComment;
 
-	function COMMENTACTIONS(&$comments) {
+	function __construct(&$comments) {
 		// call constructor of superclass first
-		$this->BaseActions();
+		parent::__construct();
 
 		// reference to the comments object
 		$this->setCommentsObj($comments);

--- a/nucleus/libs/COMMENTACTIONS.php
+++ b/nucleus/libs/COMMENTACTIONS.php
@@ -94,7 +94,7 @@ class COMMENTACTIONS extends BaseActions {
 		// begin if: member comment
 		if ($comment['memberid'] != 0)
 		{
-			$comment['authtext'] = $this->template['COMMENTS_AUTH'];
+			$comment['authtext'] = (isset($this->template['COMMENTS_AUTH'])? $this->template['COMMENTS_AUTH'] : '');
 
 			$mem =& $manager->getMember($comment['memberid']);
 			$comment['user'] = $mem->getDisplayName();
@@ -417,7 +417,8 @@ class COMMENTACTIONS extends BaseActions {
 	 * Parse templatevar userlinkraw
 	 */
 	function parse_userlinkraw() {
-		echo $this->currentComment['userlinkraw'];
+		if (isset($this->currentComment['userlinkraw']))
+		  echo $this->currentComment['userlinkraw'];
 	}
 
 	/**

--- a/nucleus/libs/COMMENTS.php
+++ b/nucleus/libs/COMMENTS.php
@@ -33,7 +33,7 @@ class COMMENTS {
 	 * @param $itemid
 	 *		id of the item
 	 */
-	function COMMENTS($itemid) {
+	function __construct($itemid) {
 		$this->itemid = intval($itemid);
 	}
 	

--- a/nucleus/libs/ENCAPSULATE.php
+++ b/nucleus/libs/ENCAPSULATE.php
@@ -49,7 +49,7 @@ class NAVLIST extends ENCAPSULATE {
 
 	public $total = null;
 
-	function NAVLIST($action, $start, $amount, $minamount, $maxamount, $blogid, $search, $itemid) {
+	function __construct($action, $start, $amount, $minamount, $maxamount, $blogid, $search, $itemid) {
 		$this->action = $action;
 		$this->start = $start;
 		$this->amount = $amount;
@@ -368,7 +368,7 @@ EOD;
  * A class used to encapsulate a list of some sort in a batch selection
  */
 class BATCH extends ENCAPSULATE {
-	function BATCH($type) {
+	function __construct($type) {
 		$this->type = $type;
 	}
 

--- a/nucleus/libs/ITEM.php
+++ b/nucleus/libs/ITEM.php
@@ -33,7 +33,7 @@ class ITEM {
 	  * @param boolean $allowfuture
 	  * @static
 	  */
-	function getitem($itemid, $allowdraft, $allowfuture) {
+	public static function getitem($itemid, $allowdraft, $allowfuture) {
 		global $manager;
 
 		$itemid = intval($itemid);
@@ -79,7 +79,7 @@ class ITEM {
 	 *
 	 * @static
 	 */
-	function createFromRequest() {
+	public static function createFromRequest() {
 		 global $member, $manager;
 
 		 $i_author = 		$member->getID();
@@ -188,7 +188,7 @@ class ITEM {
 	  *
 	  * @static
 	  */
-	function update($itemid, $catid, $title, $body, $more, $closed, $wasdraft, $publish, $timestamp = 0) {
+	public static function update($itemid, $catid, $title, $body, $more, $closed, $wasdraft, $publish, $timestamp = 0) {
 		global $manager;
 
 		$itemid = intval($itemid);
@@ -307,7 +307,7 @@ class ITEM {
 	 *
 	 * @static
 	 */
-	function move($itemid, $new_catid) {
+	public static function move($itemid, $new_catid) {
 		global $manager;
 
 		$itemid = intval($itemid);
@@ -342,7 +342,7 @@ class ITEM {
 	/**
 	  * Deletes an item
 	  */
-	function delete($itemid) {
+	public static function delete($itemid) {
 		global $manager, $member;
 
 		$itemid = intval($itemid);
@@ -378,7 +378,7 @@ class ITEM {
 	 *
 	 * @static
 	 */
-	function exists($id,$future,$draft) {
+	public static function exists($id,$future,$draft) {
 		global $manager;
 
 		$id = intval($id);
@@ -409,7 +409,7 @@ class ITEM {
 	 *
 	 * Used by xmlHTTPRequest AutoDraft
 	 */
-	function createDraftFromRequest() {
+	public static function createDraftFromRequest() {
 		global $member, $manager;
 
 		$i_author = $member->getID();

--- a/nucleus/libs/ITEM.php
+++ b/nucleus/libs/ITEM.php
@@ -21,7 +21,7 @@ class ITEM {
 	  * 
 	  * @param integer $itemid id of the item
 	  */
-	function ITEM($itemid) {
+	function __construct($itemid) {
 		$this->itemid = $itemid;
 	}
 

--- a/nucleus/libs/ITEMACTIONS.php
+++ b/nucleus/libs/ITEMACTIONS.php
@@ -35,9 +35,9 @@ class ITEMACTIONS extends BaseActions {
 	// true when comments need to be displayed
 	var $showComments;
 
-	function ITEMACTIONS(&$blog) {
+	function __construct(&$blog) {
 		// call constructor of superclass first
-		$this->BaseActions();
+		parent::__construct();
 
 		// extra parameters for created links
 		global $catid;

--- a/nucleus/libs/ITEMACTIONS.php
+++ b/nucleus/libs/ITEMACTIONS.php
@@ -527,7 +527,8 @@ class ITEMACTIONS extends BaseActions {
 		$actions->setHighlight($this->strHighlight);
 		$actions->setCurrentItem($this->currentItem);
 		//$actions->setParser($parser);
-		$parser->parse($actions->highlight($data));
+		$p_data = $actions->highlight($data);
+		$parser->parse($p_data);
 	}
 
 	/*

--- a/nucleus/libs/KARMA.php
+++ b/nucleus/libs/KARMA.php
@@ -23,7 +23,7 @@ class KARMA {
 	var $karmapos;
 	var $karmaneg;
 
-	function KARMA($itemid, $initpos = 0, $initneg = 0, $initread = 0) {
+	function __construct($itemid, $initpos = 0, $initneg = 0, $initread = 0) {
 		// itemid
 		$this->itemid = intval($itemid);
 

--- a/nucleus/libs/MANAGER.php
+++ b/nucleus/libs/MANAGER.php
@@ -57,7 +57,7 @@ class MANAGER {
       * $manager =& MANAGER::instance(); to get a reference to the object
       * instead of a copy
       */
-    function &instance() {
+    public static function &instance() {
         static $instance = array();
         if (empty($instance)) {
             $instance[0] = new MANAGER();

--- a/nucleus/libs/MANAGER.php
+++ b/nucleus/libs/MANAGER.php
@@ -68,7 +68,7 @@ class MANAGER {
     /**
       * The constructor of this class initializes the object caches
       */
-    function MANAGER() {
+    function __construct() {
         $this->items = array();
         $this->blogs = array();
         $this->plugins = array();

--- a/nucleus/libs/MEDIA.php
+++ b/nucleus/libs/MEDIA.php
@@ -280,7 +280,7 @@ class MEDIAOBJECT {
 	var $filename;
 	var $timestamp;
 
-	function MEDIAOBJECT($collection, $filename, $timestamp) {
+	function __construct($collection, $filename, $timestamp) {
 		$this->private = is_numeric($collection);
 		$this->collection = $collection;
 		$this->filename = $filename;

--- a/nucleus/libs/MEDIA.php
+++ b/nucleus/libs/MEDIA.php
@@ -26,7 +26,7 @@ class MEDIA {
 	  *
 	  * @returns array of dirname => display name
 	  */
-	function getCollectionList($exceptReadOnly = false) {
+	public static function getCollectionList($exceptReadOnly = false) {
 		global $member, $DIR_MEDIA;
 
 		$collections = array();
@@ -65,7 +65,7 @@ class MEDIA {
 	  * @param $filter
 	  *		filter on filename (defaults to none)
 	  */
-	function getMediaListByCollection($collection, $filter = '') {
+	public static function getMediaListByCollection($collection, $filter = '') {
 		global $DIR_MEDIA;
 
 		$filelist = array();
@@ -91,7 +91,7 @@ class MEDIA {
 		return $filelist;
 	}
 
-	function checkFilter($strText, $strFilter) {
+	public static function checkFilter($strText, $strFilter) {
 		if ($strFilter == '')
 			return 1;
 		else
@@ -102,7 +102,7 @@ class MEDIA {
 	  * checks if a collection exists with the given name, and if it's
 	  * allowed for the currently logged in member to upload files to it
 	  */
-	function isValidCollection($collectionName, $exceptReadOnly = false) {
+	public static function isValidCollection($collectionName, $exceptReadOnly = false) {
 		global $member, $DIR_MEDIA;
 
 		// allow creating new private directory
@@ -134,7 +134,7 @@ class MEDIA {
 	  *		the filename that should be used to save the file as
 	  *		(date prefix should be already added here)
 	  */
-	function addMediaObject($collection, $uploadfile, $filename) {
+	public static function addMediaObject($collection, $uploadfile, $filename) {
 		global $DIR_MEDIA, $manager;
 		
 		// clean filename of characters that may cause trouble in a filename using cleanFileName() function from globalfunctions.php
@@ -217,7 +217,7 @@ class MEDIA {
 	 *
 	 * NOTE: does not check if $collection is valid.
 	 */
-	function addMediaObjectRaw($collection, $filename, &$data) {
+	public static function addMediaObjectRaw($collection, $filename, &$data) {
 		global $DIR_MEDIA;
 
 		// check dir permissions (try to create dir if it does not exist)

--- a/nucleus/libs/MEMBER.php
+++ b/nucleus/libs/MEMBER.php
@@ -35,7 +35,7 @@ class MEMBER {
 	/**
 	 * Constructor for a member object
 	 */
-	function MEMBER() {
+	function __construct() {
 		global $DIR_LIBS;
 		include_once("{$DIR_LIBS}phpass.class.inc.php");
 		$this->hasher = new PasswordHash();

--- a/nucleus/libs/MEMBER.php
+++ b/nucleus/libs/MEMBER.php
@@ -46,7 +46,7 @@ class MEMBER {
 	 *
 	 * @static
 	 */
-	function &createFromName($displayname) {
+	public static function &createFromName($displayname) {
 		$mem = new MEMBER();
 		$mem->readFromName($displayname);
 		return $mem;
@@ -57,7 +57,7 @@ class MEMBER {
 	 *
 	 * @static
 	 */
-	function &createFromID($id) {
+	public static function &createFromID($id) {
 		$mem = new MEMBER();
 		$mem->readFromID($id);
 		return $mem;
@@ -625,7 +625,7 @@ class MEMBER {
 	 *
 	 * @static
 	 */
-	function exists($name) {
+	public static function exists($name) {
 		$r = sql_query('select * FROM '.sql_table('member')." WHERE mname='".sql_real_escape_string($name)."'");
 		return (sql_num_rows($r) != 0);
 	}
@@ -635,7 +635,7 @@ class MEMBER {
 	 *
 	 * @static
 	 */
-	function existsID($id) {
+	public static function existsID($id) {
 		$r = sql_query('select * FROM '.sql_table('member')." WHERE mnumber='".intval($id)."'");
 		return (sql_num_rows($r) != 0);
 	}
@@ -658,7 +658,7 @@ class MEMBER {
 	 *
 	 * @static
 	 */
-	function create($name, $realname, $password, $email, $url, $admin, $canlogin, $notes) {
+	public static function create($name, $realname, $password, $email, $url, $admin, $canlogin, $notes) {
 		if (!isValidMailAddress($email))
 		{
 			return _ERROR_BADMAILADDRESS;
@@ -715,7 +715,7 @@ class MEMBER {
 	 *
 	 * @author karma
 	 */
-	function getActivationInfo($key)
+	public static function getActivationInfo($key)
 	{
 		$query = 'SELECT * FROM ' . sql_table('activation') . ' WHERE vkey=\'' . sql_real_escape_string($key). '\'';
 		$res = sql_query($query);
@@ -790,7 +790,7 @@ class MEMBER {
 	 * there have been successfully filled out.
 	 * @author dekarma
 	 */
-	function activate($key)
+	public static function activate($key)
 	{
 		// get activate info
 		$info = MEMBER::getActivationInfo($key);
@@ -829,7 +829,7 @@ class MEMBER {
 	 *
 	 * @author dekarma
 	 */
-	function cleanupActivationTable()
+	public static function cleanupActivationTable()
 	{
 		$actdays = 2;
 		if (isset($CONF['ActivationDays']) && intval($CONF['ActivationDays']) > 0) {

--- a/nucleus/libs/NOTIFICATION.php
+++ b/nucleus/libs/NOTIFICATION.php
@@ -22,7 +22,7 @@ class NOTIFICATION {
 	  * separated by semicolons
 	  * eg: site@demuynck.org;nucleus@demuynck.org;foo@bar.com
 	  */
-	function NOTIFICATION($addresses) {
+	function __construct($addresses) {
 		$this->addresses = explode(';' , $addresses);
 	}
 

--- a/nucleus/libs/PAGEFACTORY.php
+++ b/nucleus/libs/PAGEFACTORY.php
@@ -34,7 +34,7 @@ class PAGEFACTORY extends BaseActions {
 	/**
 	 * creates a new PAGEFACTORY object
 	 */
-	function PAGEFACTORY($blogid) {
+	function __construct($blogid) {
 		// call constructor of superclass first
 		$this->BaseActions();
 

--- a/nucleus/libs/PAGEFACTORY.php
+++ b/nucleus/libs/PAGEFACTORY.php
@@ -36,7 +36,7 @@ class PAGEFACTORY extends BaseActions {
 	 */
 	function __construct($blogid) {
 		// call constructor of superclass first
-		$this->BaseActions();
+		parent::__construct();
 
 		global $manager;
 		$this->blog =& $manager->getBlog($blogid);

--- a/nucleus/libs/PARSER.php
+++ b/nucleus/libs/PARSER.php
@@ -43,7 +43,7 @@ class PARSER {
 	 * @param $delim optional delimiter
 	 * @param $paramdelim optional parameterdelimiter
 	 */
-	function PARSER($allowedActions, &$handler, $delim = '(<%|%>)', $pdelim = ',') {
+	function __construct($allowedActions, &$handler, $delim = '(<%|%>)', $pdelim = ',') {
 		$this->actions = $allowedActions;
 		$this->handler =& $handler;
 		$this->delim = $delim;

--- a/nucleus/libs/PARSER.php
+++ b/nucleus/libs/PARSER.php
@@ -163,12 +163,12 @@ class PARSER {
 		eval($command);	// execute the correct method
 	}
 
-	function setProperty($property, $value) {
+	public static function setProperty($property, $value) {
 		global $manager;
 		$manager->setParserProperty($property, $value);
 	}
 
-	function getProperty($name) {
+	public static function getProperty($name) {
 		global $manager;
 		return $manager->getParserProperty($name);
 	}

--- a/nucleus/libs/PLUGIN.php
+++ b/nucleus/libs/PLUGIN.php
@@ -550,7 +550,7 @@ class NucleusPlugin {
 	 *
 	 * (static method)
 	 */
-	function _deleteOptionValues($context, $contextid) {
+	public static function _deleteOptionValues($context, $contextid) {
 		// delete all associated plugin options
 		$aOIDs = array();
 			// find ids
@@ -573,7 +573,7 @@ class NucleusPlugin {
 	 * @author TeRanEX
 	 * @static
 	 */
-	function getOptionMeta($typeExtra) {
+	public static function getOptionMeta($typeExtra) {
 		$tmpMeta = explode(';', $typeExtra);
 		$meta = array();
 		for ($i = 0; $i < count($tmpMeta); $i++) {
@@ -594,7 +594,7 @@ class NucleusPlugin {
 	 * @return string the selectlist
 	 * @author TeRanEX
 	 */
-	function getOptionSelectValues($typeExtra) {
+	public static function getOptionSelectValues($typeExtra) {
 		$meta = NucleusPlugin::getOptionMeta($typeExtra);
 		//the select list must always be the first part
 		return $meta['select'];
@@ -630,7 +630,7 @@ class NucleusPlugin {
 	 *        formcontrols into the page (by ex: itemOptions for new item)
 	 * @static
 	 */
-	function _applyPluginOptions(&$aOptions, $newContextid = 0) {
+	public static function _applyPluginOptions(&$aOptions, $newContextid = 0) {
 		global $manager;
 		if (!is_array($aOptions)) return;
 

--- a/nucleus/libs/PLUGIN.php
+++ b/nucleus/libs/PLUGIN.php
@@ -282,7 +282,7 @@ class NucleusPlugin {
 	/**
 	 * Class constructor: Initializes some internal data
 	 */
-	function NucleusPlugin() {
+	function __construct() {
 		$this->_aOptionValues = array();	// oid_contextid => value
 		$this->_aOptionToInfo = array();	// context_name => array('oid' => ..., 'default' => ...)
 		$this->plugin_options = 0;

--- a/nucleus/libs/PLUGINADMIN.php
+++ b/nucleus/libs/PLUGINADMIN.php
@@ -20,7 +20,7 @@ class PluginAdmin {
 	var $bValid;			// evaluates to true when object is considered valid
 	var $admin;				// ref to an admin object
 
-	function PluginAdmin($pluginName)
+	function __construct($pluginName)
 	{
 		global $manager, $DIR_LIBS;
 		include_once($DIR_LIBS . 'ADMIN.php');

--- a/nucleus/libs/SEARCH.php
+++ b/nucleus/libs/SEARCH.php
@@ -25,7 +25,7 @@ class SEARCH {
 	var $inclusive;
 	var $blogs;
 
-	function SEARCH($text) {
+	function __construct($text) {
 		global $blogid;
 //		$text = preg_replace ("/[<,>,=,?,!,#,^,(,),[,\],:,;,\\\,%]/","",$text);
 		/* * * for jp * * * * * * * * * * */

--- a/nucleus/libs/SKIN.php
+++ b/nucleus/libs/SKIN.php
@@ -73,7 +73,7 @@ class SKIN {
 	 * @return int number of skins with the given ID
 	 * @static
 	 */
-	function exists($name) {
+	public static function exists($name) {
 		return quickQuery('select count(*) as result FROM '.sql_table('skin_desc').' WHERE sdname="'.sql_real_escape_string($name).'"') > 0;
 	}
 
@@ -83,7 +83,7 @@ class SKIN {
 	 * @return int number of skins with the given ID
 	 * @static
 	 */
-	function existsID($id) {
+	public static function existsID($id) {
 		return quickQuery('select COUNT(*) as result FROM '.sql_table('skin_desc').' WHERE sdnumber='.intval($id)) > 0;
 	}
 
@@ -93,7 +93,7 @@ class SKIN {
 	 * @return object SKIN
 	 * @static
 	 */
-	function createFromName($name) {
+	public static function createFromName($name) {
 		return new SKIN(SKIN::getIdFromName($name));
 	}
 
@@ -103,7 +103,7 @@ class SKIN {
 	 * @return int Skin ID
 	 * @static
 	 */
-	function getIdFromName($name) {
+	public static function getIdFromName($name) {
 		$query =  'SELECT sdnumber'
 			   . ' FROM '.sql_table('skin_desc')
 			   . ' WHERE sdname="'.sql_real_escape_string($name).'"';
@@ -118,7 +118,7 @@ class SKIN {
 	 * @return string Skin short name
 	 * @static
 	 */
-	function getNameFromId($id) {
+	public static function getNameFromId($id) {
 		return quickQuery('SELECT sdname as result FROM '.sql_table('skin_desc').' WHERE sdnumber=' . intval($id));
 	}
 
@@ -127,7 +127,7 @@ class SKIN {
 	 *
 	 * @static
 	 */
-	function createNew($name, $desc, $type = 'text/html', $includeMode = 'normal', $includePrefix = '') {
+	public static function createNew($name, $desc, $type = 'text/html', $includeMode = 'normal', $includePrefix = '') {
 		global $manager;
 
 		$param = array(
@@ -288,7 +288,7 @@ class SKIN {
 	/**
 	 * static: returns an array of friendly names
 	 */
-	function getFriendlyNames() {
+	public static function getFriendlyNames() {
 		$skintypes = array(
 			'index' => _SKIN_PART_MAIN,
 			'item' => _SKIN_PART_ITEM,
@@ -309,7 +309,7 @@ class SKIN {
 		return $skintypes;
 	}
 
-	function getAllowedActionsForType($type) {
+	public static function getAllowedActionsForType($type) {
 		global $blogid;
 
 		// some actions that can be performed at any time, from anywhere

--- a/nucleus/libs/SKIN.php
+++ b/nucleus/libs/SKIN.php
@@ -262,6 +262,10 @@ class SKIN {
 		if ($content) {
 			sql_query('INSERT INTO '.sql_table('skin')." SET scontent='" . sql_real_escape_string($content) . "', stype='" . sql_real_escape_string($type) . "', sdesc=" . intval($skinid));
 		}
+
+		global $resultCache, $manager;
+		$resultCache = array();
+		$manager->clearCachedInfo('sql_fetch_object');
 	}
 
 	/**
@@ -283,6 +287,10 @@ class SKIN {
 			   . " sdincpref='" . sql_real_escape_string($includePrefix) . "'"
 			   . " WHERE sdnumber=" . $this->getID();
 		sql_query($query);
+
+		global $resultCache, $manager;
+		$resultCache = array();
+		$manager->clearCachedInfo('sql_fetch_object');
 	}
 
 	/**

--- a/nucleus/libs/SKIN.php
+++ b/nucleus/libs/SKIN.php
@@ -28,7 +28,7 @@ class SKIN {
 	var $includePrefix;
 	var $name;
 
-	function SKIN($id) {
+	function __construct($id) {
 		global $resultCache;
 		
 		$this->id = intval($id);

--- a/nucleus/libs/TEMPLATE.php
+++ b/nucleus/libs/TEMPLATE.php
@@ -25,12 +25,12 @@ class TEMPLATE {
 	}
 
 	// (static)
-	function createFromName($name) {
+	public static function createFromName($name) {
 		return new TEMPLATE(TEMPLATE::getIdFromName($name));
 	}
 
 	// (static)
-	function getIdFromName($name) {
+	public static function getIdFromName($name) {
 		$query =  'SELECT tdnumber'
 			   . ' FROM '.sql_table('template_desc')
 			   . ' WHERE tdname="'.sql_real_escape_string($name).'"';
@@ -78,7 +78,7 @@ class TEMPLATE {
 	 *
 	 * (static)
 	 */
-	function createNew($name, $desc) {
+	public static function createNew($name, $desc) {
 		global $manager;
 
 		$param = array(
@@ -108,7 +108,7 @@ class TEMPLATE {
 	 *
 	 * @param $name name of the template file
 	 */
-	function read($name) {
+	public static function read($name) {
 		global $manager;
 		
 		$param = array(
@@ -141,7 +141,7 @@ class TEMPLATE {
 	  * @param $values
 	  *		Array of all the values
 	  */
-	function fill($template, $values) {
+	public static function fill($template, $values) {
 
 		if (sizeof($values) != 0) {
 			// go through all the values
@@ -156,25 +156,25 @@ class TEMPLATE {
 
 	// returns true if there is a template with the given shortname
 	// (static)
-	function exists($name) {
+	public static function exists($name) {
 		$r = sql_query('select * FROM '.sql_table('template_desc').' WHERE tdname="'.sql_real_escape_string($name).'"');
 		return (sql_num_rows($r) != 0);
 	}
 
 	// returns true if there is a template with the given ID
 	// (static)
-	function existsID($id) {
+	public static function existsID($id) {
 		$r = sql_query('select * FROM '.sql_table('template_desc').' WHERE tdnumber='.intval($id));
 		return (sql_num_rows($r) != 0);
 	}
 
 	// (static)
-	function getNameFromId($id) {
+	public static function getNameFromId($id) {
 		return quickQuery('SELECT tdname as result FROM '.sql_table('template_desc').' WHERE tdnumber=' . intval($id));
 	}
 
 	// (static)
-	function getDesc($id) {
+	public static function getDesc($id) {
 		$query = 'SELECT tddesc FROM '.sql_table('template_desc').' WHERE tdnumber='. intval($id);
 		$res = sql_query($query);
 		$obj = sql_fetch_object($res);

--- a/nucleus/libs/TEMPLATE.php
+++ b/nucleus/libs/TEMPLATE.php
@@ -116,6 +116,7 @@ class TEMPLATE {
 		);
 		$manager->notify('PreTemplateRead', $param);
 
+		$template = array();
 		$query = 'SELECT tpartname, tcontent'
 			   . ' FROM '.sql_table('template_desc').', '.sql_table('template')
 			   . ' WHERE tdesc=tdnumber and tdname="' . sql_real_escape_string($name) . '"';

--- a/nucleus/libs/TEMPLATE.php
+++ b/nucleus/libs/TEMPLATE.php
@@ -16,7 +16,7 @@ class TEMPLATE {
 
 	var $id;
 
-	function TEMPLATE($templateid) {
+	function __construct($templateid) {
 		$this->id = intval($templateid);
 	}
 

--- a/nucleus/libs/backup.php
+++ b/nucleus/libs/backup.php
@@ -20,7 +20,7 @@ class Backup
 	/**
 	 * Constructor
 	 */
-	function Backup()
+	function __construct()
 	{
 		// do nothing
 	}

--- a/nucleus/libs/entity.php
+++ b/nucleus/libs/entity.php
@@ -2,12 +2,12 @@
 
 class entity {
 
-	function named_to_numeric ($string) {
+	public static function named_to_numeric ($string) {
 		$string = preg_replace('/(&[0-9A-Za-z]+)(;?\=?|([^A-Za-z0-9\;\:\.\-\_]))/e', "entity::_named('\\1', '\\2') . '\\3'", $string);
 		return $string;	
 	}
 	
-	function normalize_numeric ($string) {
+	public static function normalize_numeric ($string) {
 		global $_entities;
 		$string = preg_replace('/&#([0-9]+)(;)?/e', "'&#x'.dechex('\\1').';'", $string);
 		$string = preg_replace('/&#[Xx](0)*([0-9A-Fa-f]+)(;?|([^A-Za-z0-9\;\:\.\-\_]))/e', "'&#x' . strtoupper('\\2') . ';\\4'", $string);
@@ -15,21 +15,21 @@ class entity {
 		return $string;
 	}
  
-	function numeric_to_utf8 ($string) {
+	public static function numeric_to_utf8 ($string) {
 		$string = preg_replace('/&#([0-9]+)(;)?/e', "'&#x'.dechex('\\1').';'", $string);
 		$string = preg_replace('/&#[Xx](0)*([0-9A-Fa-f]+)(;?|([^A-Za-z0-9\;\:\.\-\_]))/e', "'&#x' . strtoupper('\\2') . ';\\4'", $string);
 		$string = preg_replace('/&#x([0-9A-Fa-f]+);/e', "entity::_hex_to_utf8('\\1')", $string);		
 		return $string; 	
 	}
 
-	function numeric_to_named ($string) {
+	public static function numeric_to_named ($string) {
 		global $_entities;
 		$string = preg_replace('/&#[Xx]([0-9A-Fa-f]+)/e', "'&#'.hexdec('\\1')", $string);
 		$string = strtr($string, array_flip($_entities['named']));
 		return $string;	
 	}
 	
-	function specialchars ($string, $type = 'xml') {
+	public static function specialchars ($string, $type = 'xml') {
 		$apos = $type == 'xml' ? '&apos;' : '&#39;';
 		$specialchars = array (
 			'&quot;'	=> '&quot;',		'&amp;'   	=> '&amp;',	  	
@@ -46,7 +46,7 @@ class entity {
 	}
 	
 
-	function _hex_to_utf8($s)
+	public static function _hex_to_utf8($s)
 	{
 		$c = hexdec($s);
 	
@@ -66,7 +66,7 @@ class entity {
 		return $str;
 	} 		
 
-	function _named($entity, $extra) {
+	public static function _named($entity, $extra) {
 		global $_entities;
 		
 		if ($extra == '=') return $entity . '=';

--- a/nucleus/libs/entity.php
+++ b/nucleus/libs/entity.php
@@ -4,7 +4,7 @@ class entity {
 
 	public static function named_to_numeric ($string) {
 //		$string = preg_replace('/(&[0-9A-Za-z]+)(;?\=?|([^A-Za-z0-9\;\:\.\-\_]))/e', "entity::_named('\\1', '\\2') . '\\3'", $string);
-		$string = preg_replace_callback('/(&[0-9A-Za-z]+)(;?\=?|([^A-Za-z0-9\;\:\.\-\_]))/', array(self, 'named_to_numeric_callback') , $string);
+		$string = preg_replace_callback('/(&[0-9A-Za-z]+)(;?\=?|([^A-Za-z0-9\;\:\.\-\_]))/', 'self::named_to_numeric_callback' , $string);
 		return $string;	
 	}
 
@@ -16,10 +16,10 @@ class entity {
 	public static function normalize_numeric ($string) {
 		global $_entities;
 //		$string = preg_replace('/&#([0-9]+)(;)?/e', "'&#x'.dechex('\\1').';'", $string);
-		$string = preg_replace_callback('/&#([0-9]+)(;)?/', array(self, 'normalize_numeric_callback1') , $string);
+		$string = preg_replace_callback('/&#([0-9]+)(;)?/', 'self::normalize_numeric_callback1' , $string);
 
 //		$string = preg_replace('/&#[Xx](0)*([0-9A-Fa-f]+)(;?|([^A-Za-z0-9\;\:\.\-\_]))/e', "'&#x' . strtoupper('\\2') . ';\\4'", $string);
-		$string = preg_replace_callback('/&#[Xx](0)*([0-9A-Fa-f]+)(;?|([^A-Za-z0-9\;\:\.\-\_]))/', array(self, 'normalize_numeric_callback2') , $string);
+		$string = preg_replace_callback('/&#[Xx](0)*([0-9A-Fa-f]+)(;?|([^A-Za-z0-9\;\:\.\-\_]))/', 'self::normalize_numeric_callback2' , $string);
 
 		$string = strtr($string, $_entities['cp1251']);
 		return $string;
@@ -36,13 +36,13 @@ class entity {
  
 	public static function numeric_to_utf8 ($string) {
 //		$string = preg_replace('/&#([0-9]+)(;)?/e', "'&#x'.dechex('\\1').';'", $string);
-		$string = preg_replace_callback('/&#([0-9]+)(;)?/', array(self, 'numeric_to_utf8_callback1') , $string);
+		$string = preg_replace_callback('/&#([0-9]+)(;)?/', 'self::numeric_to_utf8_callback1' , $string);
 
 //		$string = preg_replace('/&#[Xx](0)*([0-9A-Fa-f]+)(;?|([^A-Za-z0-9\;\:\.\-\_]))/e', "'&#x' . strtoupper('\\2') . ';\\4'", $string);
-		$string = preg_replace_callback('/&#[Xx](0)*([0-9A-Fa-f]+)(;?|([^A-Za-z0-9\;\:\.\-\_]))/', array(self, 'numeric_to_utf8_callback2') , $string);
+		$string = preg_replace_callback('/&#[Xx](0)*([0-9A-Fa-f]+)(;?|([^A-Za-z0-9\;\:\.\-\_]))/', 'self::numeric_to_utf8_callback2' , $string);
 
 //		$string = preg_replace('/&#x([0-9A-Fa-f]+);/e', "entity::_hex_to_utf8('\\1')", $string);
-		$string = preg_replace_callback('/&#x([0-9A-Fa-f]+);/', array(self, 'numeric_to_utf8_callback3') , $string);
+		$string = preg_replace_callback('/&#x([0-9A-Fa-f]+);/', 'self::numeric_to_utf8_callback3' , $string);
 		
 		return $string;
 	}
@@ -63,7 +63,7 @@ class entity {
 	public static function numeric_to_named ($string) {
 		global $_entities;
 //		$string = preg_replace('/&#[Xx]([0-9A-Fa-f]+)/e', "'&#'.hexdec('\\1')", $string);
-		$string = preg_replace_callback('/&#[Xx]([0-9A-Fa-f]+)/', array(self, 'numeric_to_named_callback') , $string);
+		$string = preg_replace_callback('/&#[Xx]([0-9A-Fa-f]+)/', 'self::numeric_to_named_callback' , $string);
 		$string = strtr($string, array_flip($_entities['named']));
 		return $string;	
 	}

--- a/nucleus/libs/entity.php
+++ b/nucleus/libs/entity.php
@@ -4,7 +4,7 @@ class entity {
 
 	public static function named_to_numeric ($string) {
 //		$string = preg_replace('/(&[0-9A-Za-z]+)(;?\=?|([^A-Za-z0-9\;\:\.\-\_]))/e', "entity::_named('\\1', '\\2') . '\\3'", $string);
-		$string = preg_replace_callback('/(&[0-9A-Za-z]+)(;?\=?|([^A-Za-z0-9\;\:\.\-\_]))/', 'self::named_to_numeric_callback' , $string);
+		$string = preg_replace_callback('/(&[0-9A-Za-z]+)(;?\=?|([^A-Za-z0-9\;\:\.\-\_]))/', array(self, 'named_to_numeric_callback') , $string);
 		return $string;	
 	}
 
@@ -16,10 +16,10 @@ class entity {
 	public static function normalize_numeric ($string) {
 		global $_entities;
 //		$string = preg_replace('/&#([0-9]+)(;)?/e', "'&#x'.dechex('\\1').';'", $string);
-		$string = preg_replace_callback('/&#([0-9]+)(;)?/', 'self::normalize_numeric_callback1' , $string);
+		$string = preg_replace_callback('/&#([0-9]+)(;)?/', array(self, 'normalize_numeric_callback1') , $string);
 
 //		$string = preg_replace('/&#[Xx](0)*([0-9A-Fa-f]+)(;?|([^A-Za-z0-9\;\:\.\-\_]))/e', "'&#x' . strtoupper('\\2') . ';\\4'", $string);
-		$string = preg_replace_callback('/&#[Xx](0)*([0-9A-Fa-f]+)(;?|([^A-Za-z0-9\;\:\.\-\_]))/', 'self::normalize_numeric_callback2' , $string);
+		$string = preg_replace_callback('/&#[Xx](0)*([0-9A-Fa-f]+)(;?|([^A-Za-z0-9\;\:\.\-\_]))/', array(self, 'normalize_numeric_callback2') , $string);
 
 		$string = strtr($string, $_entities['cp1251']);
 		return $string;
@@ -36,13 +36,13 @@ class entity {
  
 	public static function numeric_to_utf8 ($string) {
 //		$string = preg_replace('/&#([0-9]+)(;)?/e', "'&#x'.dechex('\\1').';'", $string);
-		$string = preg_replace_callback('/&#([0-9]+)(;)?/', 'self::numeric_to_utf8_callback1' , $string);
+		$string = preg_replace_callback('/&#([0-9]+)(;)?/', array(self, 'numeric_to_utf8_callback1') , $string);
 
 //		$string = preg_replace('/&#[Xx](0)*([0-9A-Fa-f]+)(;?|([^A-Za-z0-9\;\:\.\-\_]))/e', "'&#x' . strtoupper('\\2') . ';\\4'", $string);
-		$string = preg_replace_callback('/&#[Xx](0)*([0-9A-Fa-f]+)(;?|([^A-Za-z0-9\;\:\.\-\_]))/', 'self::numeric_to_utf8_callback2' , $string);
+		$string = preg_replace_callback('/&#[Xx](0)*([0-9A-Fa-f]+)(;?|([^A-Za-z0-9\;\:\.\-\_]))/', array(self, 'numeric_to_utf8_callback2') , $string);
 
 //		$string = preg_replace('/&#x([0-9A-Fa-f]+);/e', "entity::_hex_to_utf8('\\1')", $string);
-		$string = preg_replace_callback('/&#x([0-9A-Fa-f]+);/', 'self::numeric_to_utf8_callback3' , $string);
+		$string = preg_replace_callback('/&#x([0-9A-Fa-f]+);/', array(self, 'numeric_to_utf8_callback3') , $string);
 		
 		return $string;
 	}
@@ -63,7 +63,7 @@ class entity {
 	public static function numeric_to_named ($string) {
 		global $_entities;
 //		$string = preg_replace('/&#[Xx]([0-9A-Fa-f]+)/e', "'&#'.hexdec('\\1')", $string);
-		$string = preg_replace_callback('/&#[Xx]([0-9A-Fa-f]+)/', 'self::numeric_to_named_callback' , $string);
+		$string = preg_replace_callback('/&#[Xx]([0-9A-Fa-f]+)/', array(self, 'numeric_to_named_callback') , $string);
 		$string = strtr($string, array_flip($_entities['named']));
 		return $string;	
 	}

--- a/nucleus/libs/entity.php
+++ b/nucleus/libs/entity.php
@@ -3,30 +3,74 @@
 class entity {
 
 	public static function named_to_numeric ($string) {
-		$string = preg_replace('/(&[0-9A-Za-z]+)(;?\=?|([^A-Za-z0-9\;\:\.\-\_]))/e', "entity::_named('\\1', '\\2') . '\\3'", $string);
+//		$string = preg_replace('/(&[0-9A-Za-z]+)(;?\=?|([^A-Za-z0-9\;\:\.\-\_]))/e', "entity::_named('\\1', '\\2') . '\\3'", $string);
+		$string = preg_replace_callback('/(&[0-9A-Za-z]+)(;?\=?|([^A-Za-z0-9\;\:\.\-\_]))/', array(self, 'named_to_numeric_callback') , $string);
 		return $string;	
 	}
-	
+
+	private static function named_to_numeric_callback ($matches) {
+//		"entity::_named('\\1', '\\2') . '\\3'"
+		return self::_named($matches[1], $matches[2]) . $matches[3];
+	}
+
 	public static function normalize_numeric ($string) {
 		global $_entities;
-		$string = preg_replace('/&#([0-9]+)(;)?/e', "'&#x'.dechex('\\1').';'", $string);
-		$string = preg_replace('/&#[Xx](0)*([0-9A-Fa-f]+)(;?|([^A-Za-z0-9\;\:\.\-\_]))/e', "'&#x' . strtoupper('\\2') . ';\\4'", $string);
+//		$string = preg_replace('/&#([0-9]+)(;)?/e', "'&#x'.dechex('\\1').';'", $string);
+		$string = preg_replace_callback('/&#([0-9]+)(;)?/', array(self, 'normalize_numeric_callback1') , $string);
+
+//		$string = preg_replace('/&#[Xx](0)*([0-9A-Fa-f]+)(;?|([^A-Za-z0-9\;\:\.\-\_]))/e', "'&#x' . strtoupper('\\2') . ';\\4'", $string);
+		$string = preg_replace_callback('/&#[Xx](0)*([0-9A-Fa-f]+)(;?|([^A-Za-z0-9\;\:\.\-\_]))/', array(self, 'normalize_numeric_callback2') , $string);
+
 		$string = strtr($string, $_entities['cp1251']);
 		return $string;
 	}
+
+	private static function normalize_numeric_callback1 ($matches) {
+//		"'&#x'.dechex('\\1').';'"
+		return '&#x'.dechex($matches[1]).';';
+	}
+	private static function normalize_numeric_callback2 ($matches) {
+//		"'&#x' . strtoupper('\\2') . ';\\4'"
+		return '&#x' . strtoupper($matches[2]) . ';' . $matches[4];
+	}
  
 	public static function numeric_to_utf8 ($string) {
-		$string = preg_replace('/&#([0-9]+)(;)?/e', "'&#x'.dechex('\\1').';'", $string);
-		$string = preg_replace('/&#[Xx](0)*([0-9A-Fa-f]+)(;?|([^A-Za-z0-9\;\:\.\-\_]))/e', "'&#x' . strtoupper('\\2') . ';\\4'", $string);
-		$string = preg_replace('/&#x([0-9A-Fa-f]+);/e', "entity::_hex_to_utf8('\\1')", $string);		
-		return $string; 	
+//		$string = preg_replace('/&#([0-9]+)(;)?/e', "'&#x'.dechex('\\1').';'", $string);
+		$string = preg_replace_callback('/&#([0-9]+)(;)?/', array(self, 'numeric_to_utf8_callback1') , $string);
+
+//		$string = preg_replace('/&#[Xx](0)*([0-9A-Fa-f]+)(;?|([^A-Za-z0-9\;\:\.\-\_]))/e', "'&#x' . strtoupper('\\2') . ';\\4'", $string);
+		$string = preg_replace_callback('/&#[Xx](0)*([0-9A-Fa-f]+)(;?|([^A-Za-z0-9\;\:\.\-\_]))/', array(self, 'numeric_to_utf8_callback2') , $string);
+
+//		$string = preg_replace('/&#x([0-9A-Fa-f]+);/e', "entity::_hex_to_utf8('\\1')", $string);
+		$string = preg_replace_callback('/&#x([0-9A-Fa-f]+);/', array(self, 'numeric_to_utf8_callback3') , $string);
+		
+		return $string;
+	}
+
+	private static function numeric_to_utf8_callback1 ($matches) {
+//		"'&#x'.dechex('\\1').';'"
+		return '&#x'.dechex($matches[1]).';';
+	}
+	private static function numeric_to_utf8_callback2 ($matches) {
+//		"'&#x' . strtoupper('\\2') . ';\\4'"
+		return '&#x' . strtoupper($matches[2]) . ';' . $matches[4];
+	}
+	private static function numeric_to_utf8_callback3 ($matches) {
+//		"entity::_hex_to_utf8('\\1')"
+		return self::_hex_to_utf8($matches[1]);
 	}
 
 	public static function numeric_to_named ($string) {
 		global $_entities;
-		$string = preg_replace('/&#[Xx]([0-9A-Fa-f]+)/e', "'&#'.hexdec('\\1')", $string);
+//		$string = preg_replace('/&#[Xx]([0-9A-Fa-f]+)/e', "'&#'.hexdec('\\1')", $string);
+		$string = preg_replace_callback('/&#[Xx]([0-9A-Fa-f]+)/', array(self, 'numeric_to_named_callback') , $string);
 		$string = strtr($string, array_flip($_entities['named']));
 		return $string;	
+	}
+
+	private static function numeric_to_named_callback ($matches) {
+//		"'&#'.hexdec('\\1')"
+		return '&#'.hexdec($matches[1]);
 	}
 	
 	public static function specialchars ($string, $type = 'xml') {

--- a/nucleus/libs/phpass.class.inc.php
+++ b/nucleus/libs/phpass.class.inc.php
@@ -30,7 +30,7 @@ class PasswordHash {
 	var $portable_hashes;
 	var $random_state;
 
-	function PasswordHash($iteration_count_log2=8, $portable_hashes=true)
+	function __construct($iteration_count_log2=8, $portable_hashes=true)
 	{
 		$this->itoa64 = './0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
 

--- a/nucleus/libs/showlist.php
+++ b/nucleus/libs/showlist.php
@@ -185,7 +185,10 @@ function listplug_table_pluginlist($template, $type) {
 				echo '</td>';
 				echo '<td>';
 				if($plug->getDescription()!=='Undefined')
-					echo encode_desc($plug->getDescription()).'<br /><br />';
+				{
+					$raw_desc = $plug->getDescription();
+					echo encode_desc($raw_desc).'<br /><br />';
+				}
 					if (sizeof($plug->getEventList()) > 0) {
 						echo _LIST_PLUGS_SUBS,'<br />',hsc(implode($plug->getEventList(),', '));
 						// check the database to see if it is up-to-date and notice the user if not
@@ -432,7 +435,7 @@ function listplug_table_commentlist($template, $type) {
                                 echo '<br />';
                                 echo hsc($current->cmail);
                         }
-			if ($current->cemail != '') {
+			if (isset($current->cemail) && ($current->cemail != '')) {
                                 echo '<br />';
                                 echo hsc($current->cemail);
                         }

--- a/nucleus/libs/skinie.php
+++ b/nucleus/libs/skinie.php
@@ -47,7 +47,7 @@ class SKINIMPORT {
 	/**
 	 * constructor initializes data structures
 	 */
-	function SKINIMPORT() {
+	function __construct() {
 		// disable magic_quotes_runtime if it's turned on
 		if (version_compare(PHP_VERSION, '5.3.0', '<')) {
 			set_magic_quotes_runtime(0);
@@ -472,7 +472,7 @@ class SKINEXPORT {
 	/**
 	 * Constructor initializes data structures
 	 */
-	function SKINEXPORT() {
+	function __construct() {
 		// list of templateIDs to export
 		$this->templates = array();
 

--- a/nucleus/libs/skinie.php
+++ b/nucleus/libs/skinie.php
@@ -435,7 +435,7 @@ class SKINIMPORT {
 	/**
 	 * Static method that looks for importable XML files in subdirs of the given dir
 	 */
-	function searchForCandidates($dir) {
+	public static function searchForCandidates($dir) {
 		$candidates = array();
 
 		$dirhandle = opendir($dir);

--- a/nucleus/libs/sql/pdo.php
+++ b/nucleus/libs/sql/pdo.php
@@ -203,8 +203,9 @@ if (!function_exists('sql_fetch_assoc'))
 			$SQL_DBH = NULL;
 			startUpError('<p>a2 Error!: ' . $e->getMessage() . '</p>', 'Connect Error');
 		}
-//		echo '<hr />DBH: '.print_r($SQL_DBH,true).'<hr />';		
-		$MYSQL_CONN &= $SQL_DBH;
+//		echo '<hr />DBH: '.print_r($SQL_DBH,true).'<hr />';
+		unset($MYSQL_CONN);
+		$MYSQL_CONN =& $SQL_DBH;
 		return $SQL_DBH;
 
 	}

--- a/nucleus/libs/xmlrpc.inc.php
+++ b/nucleus/libs/xmlrpc.inc.php
@@ -833,7 +833,7 @@ $cp1252_to_xmlent =
         * @param integer $port the port the server is listening on, defaults to 80 or 443 depending on protocol used
         * @param string $method the http protocol variant: defaults to 'http', 'https' and 'http11' can be used if CURL is installed
         */
-        function xmlrpc_client($path, $server='', $port='', $method='')
+        function __construct($path, $server='', $port='', $method='')
         {
             // allow user to specify all params in $path
             if($server == '' and $port == '' and $method == '')
@@ -1867,7 +1867,7 @@ $cp1252_to_xmlent =
         * NB: as of now we do not do it, since it might be either an xmlrpcval or a plain
         * php val, or a complete xml chunk, depending on usage of xmlrpc_client::send() inside which creator is called...
         */
-        function xmlrpcresp($val, $fcode = 0, $fstr = '', $valtyp='')
+        function __construct($val, $fcode = 0, $fstr = '', $valtyp='')
         {
             if($fcode != 0)
             {
@@ -2015,7 +2015,7 @@ xmlrpc_encode_entitites($this->errstr, $GLOBALS['xmlrpc_internalencoding'], $cha
         * @param string $meth the name of the method to invoke
         * @param array $pars array of parameters to be paased to the method (xmlrpcval objects)
         */
-        function xmlrpcmsg($meth, $pars=0)
+        function __construct($meth, $pars=0)
         {
             $this->methodname=$meth;
             if(is_array($pars) && count($pars)>0)
@@ -2625,7 +2625,7 @@ xmlrpc_encode_entitites($this->errstr, $GLOBALS['xmlrpc_internalencoding'], $cha
         * @param mixed $val
         * @param string $type any valid xmlrpc type name (lowercase). If null, 'string' is assumed
         */
-        function xmlrpcval($val=-1, $type='')
+        function __construct($val=-1, $type='')
         {
             /// @todo: optimization creep - do not call addXX, do it all inline.
             /// downside: booleans will not be coerced anymore

--- a/nucleus/libs/xmlrpcs.inc.php
+++ b/nucleus/libs/xmlrpcs.inc.php
@@ -474,7 +474,7 @@
 		* @param array $dispmap the dispatch map withd efinition of exposed services
 		* @param boolean $servicenow set to false to prevent the server from runnung upon construction
 		*/
-		function xmlrpc_server($dispMap=null, $serviceNow=true)
+		function __construct($dispMap=null, $serviceNow=true)
 		{
 			// if ZLIB is enabled, let the server by default accept compressed requests,
 			// and compress responses sent to clients that support them


### PR DESCRIPTION
PHP5.6のDeprecatedの修正 その1
Deprecated: Non-static method should not be called statically
警告がでると思われるクラス関数に static 宣言を追加しました。
PHP5.6のDeprecatedの修正 その２
entity.php
Deprecated: preg_replace(): The /e modifier is deprecated
PHP7のDeprecatedの修正