### PR TITLE
Fix 指定した日付フォーマットが反映されていない

### DIFF
--- a/nucleus/libs/ACTIONS.php
+++ b/nucleus/libs/ACTIONS.php
@@ -465,16 +465,35 @@ class ACTIONS extends BaseActions {
 	function parse_archivedate($locale = '-def-') {
 		global $archive;
 
+		// get format
+		$args = func_get_args();
+
+		// FIXME: check valid locale name
+		//       PHP7.0RC7 (win) hangup when invalid strings
+		$pattern = '@^[0-9a-z\._\-]{2,}$@i';
 		if ($locale == '-def-')
-			setlocale(LC_TIME,$template['LOCALE']);
+		{
+			// FIXME: can not determin default LOCALE
+			global $manager, $currentTemplateName;
+			if (isset($currentTemplateName) && TEMPLATE::exists($currentTemplateName))
+			{
+				$template =& $manager->getTemplate($currentTemplateName);
+				if (isset($template['LOCALE']) && preg_match($pattern, $template['LOCALE']))
+					setlocale(LC_TIME, $template['LOCALE']);
+			}
+		}
 		else
-			setlocale(LC_TIME,$locale);
+		{
+			$locale = @trim($locale);
+			if ($locale && preg_match($pattern, $locale))
+				setlocale(LC_TIME,$locale);
+			else if (func_num_args() == 1 && strlen($locale)>0)
+				array_unshift ($args, ''); // move to date format
+		}
 
 		// get archive date
 		sscanf($archive,'%d-%d-%d',$y,$m,$d);
 
-		// get format
-		$args = func_get_args();
 		// format can be spread over multiple parameters
 		if (sizeof($args) > 1) {
 			// take away locale


### PR DESCRIPTION
スキン default : 月別アーカイブページ <%archivedate(%Y年%m月)%>
index.php?blogid=1&archive=2015-11
function parse_archivedate

Fix: php7.0RC7 win版 でPHPが異常停止する問題への対応。
 index.php?blogid=1&archive=2015-11
 にアクセスするとハングアップする
 php5.x系やUnix系7.0ではphpは落ちないようです。
 原因: Nucleusがsetlocale関数に間違った値をわたしているため