### PR TITLE
以下の修正を復活。

### DIFF
--- a/nucleus/xmlrpc/server.php
+++ b/nucleus/xmlrpc/server.php
@@ -156,7 +156,8 @@ function _addDatedItem($blogid, $username, $password, $title, $body, $more, $pub
 /**
   * Updates an item. Username and password are required to login
   */
-function _edititem($itemid, $username, $password, $catid, $title, $body, $more, $wasdraft, $publish, $closed)
+//function _edititem($itemid, $username, $password, $catid, $title, $body, $more, $wasdraft, $publish, $closed)
+function _edititem($itemid, $username, $password, $catid, $title, $body, $more, $wasdraft, $publish, $closed, $timestamp=0)
 {
     global $manager;
 
@@ -181,7 +182,7 @@ function _edititem($itemid, $username, $password, $catid, $title, $body, $more, 
     }
 
     // 3. update item
-    ITEM::update($itemid, $catid, $title, $body, $more, $closed, $wasdraft, $publish, 0);
+    ITEM::update($itemid, $catid, $title, $body, $more, $closed, $wasdraft, $publish, $timestamp);
 
     return new xmlrpcresp(new xmlrpcval(1, "boolean"));
 }


### PR DESCRIPTION
api_metaweblog.inc.php
1. f_metaWeblog_newPost() :  dateCreated が送られてきた場合に、 _addDatedItem() を用いてその値を使用するよう修正。
2. f_metaWeblog_editPost() :  dateCreated が送られてきた場合に、 _edititem() にその値を渡すよう修正。
3. _categoryList() :  title, categoryId を追加し、xmlrpcresp() で返す値を 'array' に修正。('struct' ではエラーを起こす。）
4. 記事の日時のフォーマットの validate を行う validateIso8601() を追加。

server.php
1. f_edititem() : 関数の引数に$timestampを追加。ITEM::update() に 0 の替わりに$timestampを渡すよう修正。